### PR TITLE
Add reinterpreted_batch_ndims to Independent

### DIFF
--- a/distreqx/distributions/_independent.py
+++ b/distreqx/distributions/_independent.py
@@ -1,7 +1,10 @@
 """Independent distribution."""
 
+import math
 import operator
 
+import equinox as eqx
+import jax
 import jax.numpy as jnp
 import jax.tree_util as jtu
 from jaxtyping import Array, Key, PyTree
@@ -36,49 +39,158 @@ class Independent(
     """
 
     distribution: AbstractDistribution
+    reinterpreted_batch_ndims: int
 
     def __init__(
         self,
         distribution: AbstractDistribution,
+        reinterpreted_batch_ndims: int = 0,
     ):
         """Initializes an Independent distribution.
 
         **Arguments:**
 
         - `distribution`: Base distribution instance.
+        - `reinterpreted_batch_ndims`: Number of batch dimensions to reinterpret
+          as event dimensions. Defaults to 0, which preserves standard broadcasting
+          behavior for natively batched distributions (e.g., `Normal`).
+          **Note:** If you are passing a distribution that does not natively broadcast
+          and was batched using `eqx.filter_vmap` (e.g., `MultivariateNormalTri`),
+          you *must* explicitly set this to the number of mapped axes.
         """
         self.distribution = distribution
+        self.reinterpreted_batch_ndims = reinterpreted_batch_ndims
+
+    def _infer_shapes_and_dtype(self):
+        """Infer the event shape by tracing `sample`."""
+        if self.reinterpreted_batch_ndims == 0:
+            return self.distribution.event_shape, self.distribution.dtype
+
+        dummy_key = jax.random.key(0)
+
+        # Close over the key so we only map over the distribution
+        def _single_sample(d):
+            return d.sample(dummy_key)
+
+        fn = _single_sample
+        for _ in range(self.reinterpreted_batch_ndims):
+            fn = eqx.filter_vmap(fn)
+
+        shape_dtype = eqx.filter_eval_shape(fn, self.distribution)
+        return shape_dtype.shape, shape_dtype.dtype
 
     @property
-    def event_shape(self) -> tuple:
-        """Shape of event of distribution samples."""
-        return self.distribution.event_shape
+    def dtype(self) -> jnp.dtype:
+        """See `Distribution.dtype`."""
+        return self._infer_shapes_and_dtype()[1]
+
+    @property
+    def event_shape(self) -> tuple[int, ...]:
+        """See `Distribution.event_shape`."""
+        event_shape = self._infer_shapes_and_dtype()[0]
+        return event_shape
 
     def sample(self, key: Key[Array, ""]) -> Array:
         """See `Distribution.sample`."""
-        return self.distribution.sample(key)
+        if self.reinterpreted_batch_ndims == 0:
+            return self.distribution.sample(key)
+
+        bshape = self.event_shape[: self.reinterpreted_batch_ndims]
+        total_batches = math.prod(bshape)
+        keys = jax.random.split(key, total_batches).reshape(*bshape)
+
+        def _single_sample(d, k):
+            return d.sample(k)
+
+        fn = _single_sample
+        for _ in range(self.reinterpreted_batch_ndims):
+            fn = eqx.filter_vmap(fn)
+
+        return fn(self.distribution, keys)
 
     def sample_and_log_prob(self, key: Key[Array, ""]) -> tuple[Array, Array]:
         """See `Distribution.sample_and_log_prob`."""
-        samples, log_prob = self.distribution.sample_and_log_prob(key)
-        log_prob = _reduce_helper(log_prob)
-        return samples, log_prob
+        if self.reinterpreted_batch_ndims == 0:
+            samples, log_prob = self.distribution.sample_and_log_prob(key)
+            return samples, _reduce_helper(log_prob)
+
+        bshape = self.event_shape[: self.reinterpreted_batch_ndims]
+        total_batches = math.prod(bshape)
+        keys = jax.random.split(key, total_batches).reshape(*bshape)
+
+        def _single_sample_and_log_prob(d, k):
+            return d.sample_and_log_prob(k)
+
+        fn = _single_sample_and_log_prob
+        for _ in range(self.reinterpreted_batch_ndims):
+            fn = eqx.filter_vmap(fn)
+
+        samples, log_probs = fn(self.distribution, keys)
+        sum_axes = tuple(range(self.reinterpreted_batch_ndims))
+
+        return samples, jnp.sum(log_probs, axis=sum_axes)
 
     def log_prob(self, value: PyTree) -> Array:
         """See `Distribution.log_prob`."""
-        return _reduce_helper(self.distribution.log_prob(value))
+        if self.reinterpreted_batch_ndims == 0:
+            return _reduce_helper(self.distribution.log_prob(value))
+
+        def _single_log_prob(d, x):
+            return d.log_prob(x)
+
+        fn = _single_log_prob
+        for _ in range(self.reinterpreted_batch_ndims):
+            fn = eqx.filter_vmap(fn)
+
+        log_probs = fn(self.distribution, value)
+        sum_axes = tuple(range(self.reinterpreted_batch_ndims))
+        return jnp.sum(log_probs, axis=sum_axes)
 
     def entropy(self) -> Array:
         """See `Distribution.entropy`."""
-        return _reduce_helper(self.distribution.entropy())
+        if self.reinterpreted_batch_ndims == 0:
+            return _reduce_helper(self.distribution.entropy())
+
+        def _single_entropy(d):
+            return d.entropy()
+
+        fn = _single_entropy
+        for _ in range(self.reinterpreted_batch_ndims):
+            fn = eqx.filter_vmap(fn)
+
+        entropies = fn(self.distribution)
+        sum_axes = tuple(range(self.reinterpreted_batch_ndims))
+        return jnp.sum(entropies, axis=sum_axes)
 
     def log_cdf(self, value: PyTree) -> Array:
         """See `Distribution.log_cdf`."""
-        return _reduce_helper(self.distribution.log_cdf(value))
+        if self.reinterpreted_batch_ndims == 0:
+            return _reduce_helper(self.distribution.log_cdf(value))
+
+        def _single_log_cdf(d, x):
+            return d.log_cdf(x)
+
+        fn = _single_log_cdf
+        for _ in range(self.reinterpreted_batch_ndims):
+            fn = eqx.filter_vmap(fn)
+
+        log_cdfs = fn(self.distribution, value)
+        sum_axes = tuple(range(self.reinterpreted_batch_ndims))
+        return jnp.sum(log_cdfs, axis=sum_axes)
 
     def mean(self) -> Array:
         """Calculates the mean."""
-        return self.distribution.mean()
+        if self.reinterpreted_batch_ndims == 0:
+            return self.distribution.mean()
+
+        def _single_mean(d):
+            return d.mean()
+
+        fn = _single_mean
+        for _ in range(self.reinterpreted_batch_ndims):
+            fn = eqx.filter_vmap(fn)
+
+        return fn(self.distribution)
 
     def icdf(self, value: Array) -> Array:
         """See `Distribution.icdf`."""
@@ -86,26 +198,66 @@ class Independent(
 
     def median(self) -> Array:
         """Calculates the median."""
-        return self.distribution.median()
+        if self.reinterpreted_batch_ndims == 0:
+            return self.distribution.median()
+
+        def _single_median(d):
+            return d.median()
+
+        fn = _single_median
+        for _ in range(self.reinterpreted_batch_ndims):
+            fn = eqx.filter_vmap(fn)
+
+        return fn(self.distribution)
 
     def variance(self) -> Array:
         """Calculates the variance."""
-        return self.distribution.variance()
+        if self.reinterpreted_batch_ndims == 0:
+            return self.distribution.variance()
+
+        def _single_variance(d):
+            return d.variance()
+
+        fn = _single_variance
+        for _ in range(self.reinterpreted_batch_ndims):
+            fn = eqx.filter_vmap(fn)
+
+        return fn(self.distribution)
 
     def stddev(self) -> Array:
         """Calculates the standard deviation."""
-        return self.distribution.stddev()
+        if self.reinterpreted_batch_ndims == 0:
+            return self.distribution.stddev()
+
+        def _single_stddev(d):
+            return d.stddev()
+
+        fn = _single_stddev
+        for _ in range(self.reinterpreted_batch_ndims):
+            fn = eqx.filter_vmap(fn)
+
+        return fn(self.distribution)
 
     def mode(self) -> Array:
         """Calculates the mode."""
-        return self.distribution.mode()
+        if self.reinterpreted_batch_ndims == 0:
+            return self.distribution.mode()
+
+        def _single_mode(d):
+            return d.mode()
+
+        fn = _single_mode
+        for _ in range(self.reinterpreted_batch_ndims):
+            fn = eqx.filter_vmap(fn)
+
+        return fn(self.distribution)
 
     def kl_divergence(self, other_dist, **kwargs) -> Array:
         """Calculates the KL divergence to another distribution.
 
         **Arguments:**
 
-        - `other_dist`: A compatible disteqx distribution.
+        - `other_dist`: A compatible distreqx distribution.
         - `kwargs`: Additional kwargs.
 
         **Returns:**
@@ -118,13 +270,33 @@ class Independent(
         q = dist2.distribution
 
         if dist1.event_shape == dist2.event_shape:
-            if p.event_shape == q.event_shape:
-                kl_divergence = _reduce_helper(p.kl_divergence(q))
+            # Safely extract the base event shapes without triggering unsafe traces
+            # on the raw, un-wrapped vmapped inner distributions.
+            d1_rndims = dist1.reinterpreted_batch_ndims
+            d2_rndims = dist2.reinterpreted_batch_ndims
+            p_base_shape = dist1.event_shape[d1_rndims:]  # fmt: skip
+            q_base_shape = dist2.event_shape[d2_rndims:]  # fmt: skip
+
+            if p_base_shape == q_base_shape:
+                if self.reinterpreted_batch_ndims == 0:
+                    kl_divergence = _reduce_helper(p.kl_divergence(q))
+                else:
+
+                    def _single_kl(d1, d2):
+                        return d1.kl_divergence(d2)
+
+                    fn = _single_kl
+                    for _ in range(self.reinterpreted_batch_ndims):
+                        fn = eqx.filter_vmap(fn)
+
+                    kl_divs = fn(p, q)
+                    sum_axes = tuple(range(self.reinterpreted_batch_ndims))
+                    kl_divergence = jnp.sum(kl_divs, axis=sum_axes)
             else:
                 raise NotImplementedError(
                     f"KL between Independents whose inner distributions have different "
-                    f"event shapes is not supported: obtained {p.event_shape} and "
-                    f"{q.event_shape}."
+                    f"event shapes is not supported: obtained {p_base_shape} and "
+                    f"{q_base_shape}."
                 )
         else:
             raise ValueError(

--- a/distreqx/distributions/_independent.py
+++ b/distreqx/distributions/_independent.py
@@ -1,7 +1,10 @@
 """Independent distribution."""
 
+import math
 import operator
 
+import equinox as eqx
+import jax
 import jax.numpy as jnp
 import jax.tree_util as jtu
 from jaxtyping import Array, Key, PyTree
@@ -35,23 +38,82 @@ class Independent(
     """
 
     distribution: AbstractDistribution
+    reinterpreted_batch_ndims: int
 
     def __init__(
         self,
         distribution: AbstractDistribution,
+        reinterpreted_batch_ndims: int = 0,
     ):
         """Initializes an Independent distribution.
 
         **Arguments:**
 
         - `distribution`: Base distribution instance.
+        - `reinterpreted_batch_ndims`: Number of batch dimensions to reinterpret
+          as event dimensions. Defaults to 0, which preserves standard broadcasting
+          behavior for natively batched distributions (e.g., `Normal`).
+
+        !!! note
+
+            If you are passing a distribution that does not natively broadcast
+            and was batched using `eqx.filter_vmap` (e.g., `MultivariateNormalTri`),
+            you *must* explicitly set `reinterpreted_batch_ndims` to the number of
+            mapped axes.
         """
         self.distribution = distribution
+        self.reinterpreted_batch_ndims = reinterpreted_batch_ndims
+
+    def _vmap_method(self, method_name: str, obj, *args):
+        """Calls `getattr(obj, method_name)(*args)`, vmapping over `obj` and
+        `args` `reinterpreted_batch_ndims` times (a no-op when it's 0)."""
+
+        def _single(o, *a):
+            return getattr(o, method_name)(*a)
+
+        fn = _single
+        for _ in range(self.reinterpreted_batch_ndims):
+            fn = eqx.filter_vmap(fn)
+        return fn(obj, *args)
+
+    def _vmap_and_sum(self, method_name: str, obj, *args):
+        """As `_vmap_method`, but additionally sums the result over the
+        reinterpreted batch axes (or fully reduces the pytree when there are
+        none, matching `reinterpreted_batch_ndims == 0`)."""
+        if self.reinterpreted_batch_ndims == 0:
+            return _reduce_helper(getattr(obj, method_name)(*args))
+        result = self._vmap_method(method_name, obj, *args)
+        sum_axes = tuple(range(self.reinterpreted_batch_ndims))
+        return jnp.sum(result, axis=sum_axes)
+
+    def _infer_shapes_and_dtype(self):
+        """Infer the event shape by tracing `sample`."""
+        if self.reinterpreted_batch_ndims == 0:
+            return self.distribution.event_shape, self.distribution.dtype
+
+        dummy_key = jax.random.key(0)
+
+        # Close over the key so we only map over the distribution
+        def _single_sample(d):
+            return d.sample(dummy_key)
+
+        fn = _single_sample
+        for _ in range(self.reinterpreted_batch_ndims):
+            fn = eqx.filter_vmap(fn)
+
+        shape_dtype = eqx.filter_eval_shape(fn, self.distribution)
+        return shape_dtype.shape, shape_dtype.dtype
 
     @property
-    def event_shape(self) -> tuple:
-        """Shape of event of distribution samples."""
-        return self.distribution.event_shape
+    def dtype(self) -> jnp.dtype:
+        """See `Distribution.dtype`."""
+        return self._infer_shapes_and_dtype()[1]
+
+    @property
+    def event_shape(self) -> tuple[int, ...]:
+        """See `Distribution.event_shape`."""
+        event_shape = self._infer_shapes_and_dtype()[0]
+        return event_shape
 
     @property
     def support(self) -> tuple[Array, Array]:
@@ -60,29 +122,45 @@ class Independent(
 
     def sample(self, key: Key[Array, ""]) -> Array:
         """See `Distribution.sample`."""
-        return self.distribution.sample(key)
+        if self.reinterpreted_batch_ndims == 0:
+            return self.distribution.sample(key)
+
+        bshape = self.event_shape[: self.reinterpreted_batch_ndims]
+        total_batches = math.prod(bshape)
+        keys = jax.random.split(key, total_batches).reshape(*bshape)
+        return self._vmap_method("sample", self.distribution, keys)
 
     def sample_and_log_prob(self, key: Key[Array, ""]) -> tuple[Array, Array]:
         """See `Distribution.sample_and_log_prob`."""
-        samples, log_prob = self.distribution.sample_and_log_prob(key)
-        log_prob = _reduce_helper(log_prob)
-        return samples, log_prob
+        if self.reinterpreted_batch_ndims == 0:
+            samples, log_prob = self.distribution.sample_and_log_prob(key)
+            return samples, _reduce_helper(log_prob)
+
+        bshape = self.event_shape[: self.reinterpreted_batch_ndims]
+        total_batches = math.prod(bshape)
+        keys = jax.random.split(key, total_batches).reshape(*bshape)
+
+        samples, log_probs = self._vmap_method(
+            "sample_and_log_prob", self.distribution, keys
+        )
+        sum_axes = tuple(range(self.reinterpreted_batch_ndims))
+        return samples, jnp.sum(log_probs, axis=sum_axes)
 
     def log_prob(self, value: PyTree) -> Array:
         """See `Distribution.log_prob`."""
-        return _reduce_helper(self.distribution.log_prob(value))
+        return self._vmap_and_sum("log_prob", self.distribution, value)
 
     def entropy(self) -> Array:
         """See `Distribution.entropy`."""
-        return _reduce_helper(self.distribution.entropy())
+        return self._vmap_and_sum("entropy", self.distribution)
 
     def log_cdf(self, value: PyTree) -> Array:
         """See `Distribution.log_cdf`."""
-        return _reduce_helper(self.distribution.log_cdf(value))
+        return self._vmap_and_sum("log_cdf", self.distribution, value)
 
     def mean(self) -> Array:
         """Calculates the mean."""
-        return self.distribution.mean()
+        return self._vmap_method("mean", self.distribution)
 
     def icdf(self, value: Array) -> Array:
         """See `Distribution.icdf`."""
@@ -90,26 +168,26 @@ class Independent(
 
     def median(self) -> Array:
         """Calculates the median."""
-        return self.distribution.median()
+        return self._vmap_method("median", self.distribution)
 
     def variance(self) -> Array:
         """Calculates the variance."""
-        return self.distribution.variance()
+        return self._vmap_method("variance", self.distribution)
 
     def stddev(self) -> Array:
         """Calculates the standard deviation."""
-        return self.distribution.stddev()
+        return self._vmap_method("stddev", self.distribution)
 
     def mode(self) -> Array:
         """Calculates the mode."""
-        return self.distribution.mode()
+        return self._vmap_method("mode", self.distribution)
 
     def kl_divergence(self, other_dist, **kwargs) -> Array:
         """Calculates the KL divergence to another distribution.
 
         **Arguments:**
 
-        - `other_dist`: A compatible disteqx distribution.
+        - `other_dist`: A compatible distreqx distribution.
         - `kwargs`: Additional kwargs.
 
         **Returns:**
@@ -121,19 +199,32 @@ class Independent(
         p = dist1.distribution
         q = dist2.distribution
 
-        if dist1.event_shape == dist2.event_shape:
-            if p.event_shape == q.event_shape:
-                kl_divergence = _reduce_helper(p.kl_divergence(q))
-            else:
-                raise NotImplementedError(
-                    f"KL between Independents whose inner distributions have different "
-                    f"event shapes is not supported: obtained {p.event_shape} and "
-                    f"{q.event_shape}."
-                )
-        else:
+        if dist1.event_shape != dist2.event_shape:
             raise ValueError(
                 f"Event shapes {dist1.event_shape} and {dist2.event_shape}"
                 f" do not match."
             )
 
-        return kl_divergence
+        d1_rndims = dist1.reinterpreted_batch_ndims
+        d2_rndims = dist2.reinterpreted_batch_ndims
+        if d1_rndims != d2_rndims:
+            # A mismatch here would silently sum over the wrong number of axes
+            # on one side, so we enforce it rather than guess.
+            raise ValueError(
+                f"KL between Independents requires matching "
+                f"`reinterpreted_batch_ndims`: got {d1_rndims} and {d2_rndims}."
+            )
+
+        # Safely extract the base event shapes without triggering unsafe traces
+        # on the raw, un-wrapped vmapped inner distributions.
+        p_base_shape = dist1.event_shape[d1_rndims:]
+        q_base_shape = dist2.event_shape[d2_rndims:]
+
+        if p_base_shape != q_base_shape:
+            raise NotImplementedError(
+                f"KL between Independents whose inner distributions have different "
+                f"event shapes is not supported: obtained {p_base_shape} and "
+                f"{q_base_shape}."
+            )
+
+        return self._vmap_and_sum("kl_divergence", p, q)

--- a/tests/independent_test.py
+++ b/tests/independent_test.py
@@ -3,25 +3,188 @@
 from unittest import TestCase
 
 import equinox as eqx
+import jax
 import jax.numpy as jnp
 import numpy as np
 
-from distreqx.distributions import Independent, Normal
+from distreqx.distributions import Independent, MultivariateNormalTri, Normal
 
 
 class IndependentTest(TestCase):
     """Class to test miscellaneous methods of the `Independent` distribution."""
 
     def setUp(self):
+        np.random.seed(42)
         self.loc = jnp.array(np.random.randn(2, 3, 4))
         self.scale = jnp.array(np.abs(np.random.randn(2, 3, 4)))
         self.base = Normal(loc=self.loc, scale=self.scale)
         self.dist = Independent(self.base)
+        self.key = jax.random.key(0)
 
-    def assertion_fn(self, rtol):
+    def assertion_fn(self, rtol=1e-5):
         return lambda x, y: np.testing.assert_allclose(x, y, rtol=rtol)
+
+    def _create_vmapped_mvn(self, M=20, N=10, D=3):
+        """Helper to generate a 2D vmapped MultivariateNormalTri."""
+        locs = jnp.zeros((M, N, D))
+        scales_tri = jnp.stack([jnp.tri(D)] * M * N, axis=0).reshape(M, N, D, D)
+        batch_mvn = eqx.filter_vmap(eqx.filter_vmap(MultivariateNormalTri))(
+            locs, scales_tri
+        )
+        return batch_mvn, locs, scales_tri
+
+    # --- 1. Basic & Legacy Tests ---
 
     def test_constructor_is_jittable_given_ndims(self):
         constructor = lambda d: Independent(d)
         model = eqx.filter_jit(constructor)(self.base)
         self.assertIsInstance(model, Independent)
+
+    def test_legacy_broadcasting_behavior(self):
+        """Tests the reinterpreted_batch_ndims=0 fallback for standard distributions."""
+        xs = jnp.ones((2, 3, 4))
+
+        # event_shape should perfectly match the base distribution
+        self.assertEqual(self.dist.event_shape, self.base.event_shape)
+
+        # log_prob should sum over all leaves via _reduce_helper
+        expected_log_prob = jnp.sum(self.base.log_prob(xs))
+        self.assertion_fn()(self.dist.log_prob(xs), expected_log_prob)
+
+    # --- 2. Shape Inference Tests ---
+
+    def test_mapped_event_shape_inference(self):
+        """
+        Tests the eqx.filter_eval_shape logic
+        for dynamically vmapped distributions.
+        """
+        M, N, D = 20, 10, 3
+
+        # --- Test 1D reinterpretation ---
+        # Create a distribution vmapped exactly ONCE
+        locs_1d = jnp.zeros((M, D))
+        scales_tri_1d = jnp.stack([jnp.tri(D)] * M, axis=0).reshape(M, D, D)
+        batch_mvn_1d = eqx.filter_vmap(MultivariateNormalTri)(locs_1d, scales_tri_1d)
+
+        indep_1d = Independent(batch_mvn_1d, reinterpreted_batch_ndims=1)
+        self.assertEqual(
+            indep_1d.event_shape, (M, D)
+        )  # (20, 3) because base is (3,) and 1st vmap is over M
+
+        # --- Test 2D reinterpretation ---
+        # Create a distribution vmapped exactly TWICE using our helper
+        batch_mvn_2d, _, _ = self._create_vmapped_mvn(M, N, D)
+
+        indep_2d = Independent(batch_mvn_2d, reinterpreted_batch_ndims=2)
+        self.assertEqual(indep_2d.event_shape, (M, N, D))  # (20, 10, 3)
+
+    # --- 3. Log Prob & Sampling Equivalence Tests ---
+
+    def test_multiple_reinterpret_log_prob(self):
+        """Tests that stacked mapped log_probs evaluate correctly."""
+        M, N, D = 20, 10, 3
+        batch_mvn, locs, scales_tri = self._create_vmapped_mvn(M, N, D)
+        xs = jnp.ones((M, N, D))
+
+        mvn = Independent(batch_mvn, reinterpreted_batch_ndims=2)
+
+        # Get the underlying log prob and multiply by the number
+        # of independent dimensions (Since all locs and scales are
+        # identical in this test setup, summing is equal to multiplying)
+        log_prob_underlying = (
+            MultivariateNormalTri(locs[0][0], scales_tri[0][0]).log_prob(xs[0][0])
+            * M
+            * N
+        )
+        log_prob_independent = mvn.log_prob(xs)
+
+        self.assertion_fn(1e-5)(log_prob_underlying, log_prob_independent)
+
+    def test_sample_and_log_prob_equivalence(self):
+        """
+        Tests PRNG key splitting logic and equivalence
+        to separate sample + log_prob calls.
+        """
+        M, N, D = 5, 4, 3
+        batch_mvn, _, _ = self._create_vmapped_mvn(M, N, D)
+        mvn = Independent(batch_mvn, reinterpreted_batch_ndims=2)
+
+        # Draw from sample_and_log_prob
+        samples, log_probs = mvn.sample_and_log_prob(self.key)
+
+        # Verify sample shape
+        self.assertEqual(samples.shape, mvn.event_shape)
+
+        # Verify log_prob from sample_and_log_prob matches a manual call to log_prob
+        expected_log_probs = mvn.log_prob(samples)
+        self.assertion_fn()(log_probs, expected_log_probs)
+
+    # --- 4. Moments & Descriptors ---
+
+    def test_moments_and_entropy(self):
+        """Tests that moments map correctly and entropy sums over the right axes."""
+        M, N, D = 5, 4, 3
+        batch_mvn, locs, _ = self._create_vmapped_mvn(M, N, D)
+        mvn = Independent(batch_mvn, reinterpreted_batch_ndims=2)
+
+        # Mean should be the shape of the full reinterpreted event
+        mean = mvn.mean()
+        self.assertEqual(mean.shape, (M, N, D))
+        self.assertion_fn()(mean, locs)  # For a MVN with zero locs, mean is zeros
+
+        # Variance should also map correctly without crashing
+        variance = mvn.variance()
+        self.assertEqual(variance.shape, (M, N, D))
+
+        # Entropy should be summed over the 2 reinterpreted dimensions
+        entropy = mvn.entropy()
+        self.assertEqual(entropy.shape, ())  # Reduced to scalar
+
+    # --- 5. KL Divergence ---
+
+    def test_kl_divergence(self):
+        """
+        Tests that KL divergence maps and sums correctly
+        between identical/different distributions.
+        """
+        M, N, D = 5, 4, 3
+        batch_mvn_p, _, scales_tri_p = self._create_vmapped_mvn(M, N, D)
+
+        # Create a second distribution with slightly different scales
+        locs_q = jnp.zeros((M, N, D))
+        scales_tri_q = scales_tri_p * 2.0
+        batch_mvn_q = eqx.filter_vmap(eqx.filter_vmap(MultivariateNormalTri))(
+            locs_q, scales_tri_q
+        )
+
+        p = Independent(batch_mvn_p, reinterpreted_batch_ndims=2)
+        q = Independent(batch_mvn_q, reinterpreted_batch_ndims=2)
+
+        # KL(p || p) should be 0
+        kl_self = p.kl_divergence(p)
+        self.assertion_fn()(kl_self, 0.0)
+
+        # KL(p || q) should evaluate properly and reduce to a scalar
+        kl_pq = p.kl_divergence(q)
+        self.assertEqual(kl_pq.shape, ())
+        self.assertTrue(kl_pq > 0.0)  # KL should be strictly positive
+
+    # --- 6. Execution & JIT Safety ---
+
+    def test_methods_are_jittable(self):
+        """Ensures that wrapped mapping logic survives JAX compilation."""
+        M, N, D = 5, 4, 3
+        batch_mvn, _, _ = self._create_vmapped_mvn(M, N, D)
+        mvn = Independent(batch_mvn, reinterpreted_batch_ndims=2)
+        xs = jnp.ones((M, N, D))
+
+        # JIT compile the log_prob and sample methods
+        jitted_log_prob = eqx.filter_jit(lambda d, x: d.log_prob(x))
+        jitted_sample = eqx.filter_jit(lambda d, k: d.sample(k))
+
+        # If abstract tracing or shape inference fails, these will crash
+        lp = jitted_log_prob(mvn, xs)
+        samples = jitted_sample(mvn, self.key)
+
+        self.assertEqual(lp.shape, ())
+        self.assertEqual(samples.shape, (M, N, D))

--- a/tests/independent_test.py
+++ b/tests/independent_test.py
@@ -3,25 +3,201 @@
 from unittest import TestCase
 
 import equinox as eqx
+import jax
 import jax.numpy as jnp
 import numpy as np
 
-from distreqx.distributions import Independent, Normal
+from distreqx.distributions import Bernoulli, Independent, MultivariateNormalTri, Normal
 
 
 class IndependentTest(TestCase):
     """Class to test miscellaneous methods of the `Independent` distribution."""
 
     def setUp(self):
+        np.random.seed(42)
         self.loc = jnp.array(np.random.randn(2, 3, 4))
         self.scale = jnp.array(np.abs(np.random.randn(2, 3, 4)))
         self.base = Normal(loc=self.loc, scale=self.scale)
         self.dist = Independent(self.base)
+        self.key = jax.random.key(0)
 
-    def assertion_fn(self, rtol):
+    def assertion_fn(self, rtol=1e-5):
         return lambda x, y: np.testing.assert_allclose(x, y, rtol=rtol)
+
+    def _create_vmapped_mvn(self, M=20, N=10, D=3):
+        """Helper to generate a 2D vmapped MultivariateNormalTri."""
+        locs = jnp.zeros((M, N, D))
+        scales_tri = jnp.stack([jnp.tri(D)] * M * N, axis=0).reshape(M, N, D, D)
+        batch_mvn = eqx.filter_vmap(eqx.filter_vmap(MultivariateNormalTri))(
+            locs, scales_tri
+        )
+        return batch_mvn, locs, scales_tri
 
     def test_constructor_is_jittable_given_ndims(self):
         constructor = lambda d: Independent(d)
         model = eqx.filter_jit(constructor)(self.base)
         self.assertIsInstance(model, Independent)
+
+    def test_mapped_event_shape_inference(self):
+        """
+        Tests the eqx.filter_eval_shape logic
+        for dynamically vmapped distributions.
+        """
+        M, N, D = 20, 10, 3
+
+        # Create a distribution vmapped exactly ONCE
+        locs_1d = jnp.zeros((M, D))
+        scales_tri_1d = jnp.stack([jnp.tri(D)] * M, axis=0).reshape(M, D, D)
+        batch_mvn_1d = eqx.filter_vmap(MultivariateNormalTri)(locs_1d, scales_tri_1d)
+
+        indep_1d = Independent(batch_mvn_1d, reinterpreted_batch_ndims=1)
+        self.assertEqual(
+            indep_1d.event_shape, (M, D)
+        )  # (20, 3) because base is (3,) and 1st vmap is over M
+
+        # Create a distribution vmapped exactly TWICE using our helper
+        batch_mvn_2d, _, _ = self._create_vmapped_mvn(M, N, D)
+
+        indep_2d = Independent(batch_mvn_2d, reinterpreted_batch_ndims=2)
+        self.assertEqual(indep_2d.event_shape, (M, N, D))  # (20, 10, 3)
+
+    def test_multiple_reinterpret_log_prob(self):
+        """Tests that stacked mapped log_probs evaluate correctly."""
+        M, N, D = 20, 10, 3
+        batch_mvn, locs, scales_tri = self._create_vmapped_mvn(M, N, D)
+        xs = jnp.ones((M, N, D))
+
+        mvn = Independent(batch_mvn, reinterpreted_batch_ndims=2)
+
+        # Get the underlying log prob and multiply by the number
+        # of independent dimensions (Since all locs and scales are
+        # identical in this test setup, summing is equal to multiplying)
+        log_prob_underlying = (
+            MultivariateNormalTri(locs[0][0], scales_tri[0][0]).log_prob(xs[0][0])
+            * M
+            * N
+        )
+        log_prob_independent = mvn.log_prob(xs)
+
+        self.assertion_fn(1e-5)(log_prob_underlying, log_prob_independent)
+
+    def test_sample_and_log_prob_equivalence(self):
+        """
+        Tests PRNG key splitting logic and equivalence
+        to separate sample + log_prob calls.
+        """
+        M, N, D = 5, 4, 3
+        batch_mvn, _, _ = self._create_vmapped_mvn(M, N, D)
+        mvn = Independent(batch_mvn, reinterpreted_batch_ndims=2)
+
+        # Draw from sample_and_log_prob
+        samples, log_probs = mvn.sample_and_log_prob(self.key)
+
+        # Verify sample shape
+        self.assertEqual(samples.shape, mvn.event_shape)
+
+        # Verify log_prob from sample_and_log_prob matches a manual call to log_prob
+        expected_log_probs = mvn.log_prob(samples)
+        self.assertion_fn()(log_probs, expected_log_probs)
+
+    def test_moments_and_entropy(self):
+        """Tests that moments map correctly and entropy sums over the right axes."""
+        M, N, D = 5, 4, 3
+        batch_mvn, locs, _ = self._create_vmapped_mvn(M, N, D)
+        mvn = Independent(batch_mvn, reinterpreted_batch_ndims=2)
+
+        # Mean should be the shape of the full reinterpreted event
+        mean = mvn.mean()
+        self.assertEqual(mean.shape, (M, N, D))
+        self.assertion_fn()(mean, locs)  # For a MVN with zero locs, mean is zeros
+
+        # Variance should also map correctly without crashing
+        variance = mvn.variance()
+        self.assertEqual(variance.shape, (M, N, D))
+
+        # Entropy should be summed over the 2 reinterpreted dimensions
+        entropy = mvn.entropy()
+        self.assertEqual(entropy.shape, ())  # Reduced to scalar
+
+    def test_kl_divergence(self):
+        """
+        Tests that KL divergence maps and sums correctly
+        between identical/different distributions.
+        """
+        M, N, D = 5, 4, 3
+        batch_mvn_p, _, scales_tri_p = self._create_vmapped_mvn(M, N, D)
+
+        # Create a second distribution with slightly different scales
+        locs_q = jnp.zeros((M, N, D))
+        scales_tri_q = scales_tri_p * 2.0
+        batch_mvn_q = eqx.filter_vmap(eqx.filter_vmap(MultivariateNormalTri))(
+            locs_q, scales_tri_q
+        )
+
+        p = Independent(batch_mvn_p, reinterpreted_batch_ndims=2)
+        q = Independent(batch_mvn_q, reinterpreted_batch_ndims=2)
+
+        # KL(p || p) should be 0
+        kl_self = p.kl_divergence(p)
+        self.assertion_fn()(kl_self, 0.0)
+
+        # KL(p || q) should evaluate properly and reduce to a scalar
+        kl_pq = p.kl_divergence(q)
+        self.assertEqual(kl_pq.shape, ())
+        self.assertTrue(kl_pq > 0.0)  # KL should be strictly positive
+
+    def test_reinterpretation_across_distribution_types(self):
+        """Checks reinterpretation doesn't misbehave for natively-broadcasting
+        distributions other than Normal (e.g. discrete distributions like
+        Bernoulli), not just the vmap-constructed MultivariateNormalTri case."""
+        M, N = 5, 4
+
+        bernoulli = Bernoulli(probs=jnp.full((M, N), 0.3))
+        indep_bernoulli = Independent(bernoulli, reinterpreted_batch_ndims=2)
+        self.assertEqual(indep_bernoulli.event_shape, (M, N))
+
+        xs = jnp.ones((M, N))
+        expected_log_prob = jnp.sum(bernoulli.log_prob(xs))
+        self.assertion_fn()(indep_bernoulli.log_prob(xs), expected_log_prob)
+
+        sample = indep_bernoulli.sample(self.key)
+        self.assertEqual(sample.shape, (M, N))
+
+        mean = indep_bernoulli.mean()
+        self.assertEqual(mean.shape, (M, N))
+
+        normal = Normal(loc=jnp.zeros((M, N)), scale=jnp.ones((M, N)))
+        indep_normal = Independent(normal, reinterpreted_batch_ndims=1)
+        self.assertEqual(indep_normal.event_shape, (M, N))
+        self.assertion_fn()(
+            indep_normal.log_prob(xs), jnp.sum(normal.log_prob(xs), axis=0)
+        )
+
+    def test_kl_divergence_requires_matching_reinterpreted_batch_ndims(self):
+        # Same underlying (natively-broadcasting) distribution and event_shape,
+        # but reinterpreted over a different number of axes.
+        normal = Normal(loc=jnp.zeros((5, 4)), scale=jnp.ones((5, 4)))
+        p = Independent(normal, reinterpreted_batch_ndims=2)
+        q = Independent(normal, reinterpreted_batch_ndims=1)
+        self.assertEqual(p.event_shape, q.event_shape)
+
+        with self.assertRaisesRegex(ValueError, "reinterpreted_batch_ndims"):
+            p.kl_divergence(q)
+
+    def test_methods_are_jittable(self):
+        """Ensures that wrapped mapping logic survives JAX compilation."""
+        M, N, D = 5, 4, 3
+        batch_mvn, _, _ = self._create_vmapped_mvn(M, N, D)
+        mvn = Independent(batch_mvn, reinterpreted_batch_ndims=2)
+        xs = jnp.ones((M, N, D))
+
+        # JIT compile the log_prob and sample methods
+        jitted_log_prob = eqx.filter_jit(lambda d, x: d.log_prob(x))
+        jitted_sample = eqx.filter_jit(lambda d, k: d.sample(k))
+
+        # If abstract tracing or shape inference fails, these will crash
+        lp = jitted_log_prob(mvn, xs)
+        samples = jitted_sample(mvn, self.key)
+
+        self.assertEqual(lp.shape, ())
+        self.assertEqual(samples.shape, (M, N, D))


### PR DESCRIPTION
Adds `reinterpreted_batch_ndims` to `Independent`, to support distributions that have been batched via eqx.filter_vmap (e.g., `MultivariateNormalTri`) that don't support handle batched arrays natively.

Although distreqx has expressly dropped the concept of batch dimensions throughout the codebase (which I strongly agree was the right choice), I do believe `Independent` still requires a `reinterpreted_batch_ndims` options, with motivation in the example below.

Without this PR, passing a vmapped distribution that doesn't natively support broadcasing to `Independent` crashes on methods like `log_prob`, because the inner computations weren't being appropriately mapped. This change allows users to explicitly define the number of mapped axes, letting `Independent` correctly unroll the vmap layers and reduce the results to a single scalar. The previous behaviour is left unaffected with the default of `reinterpreted_batch_ndims = 0`.

```python
locs = jnp.zeros((20, 10, 3))
scales_tri = jnp.stack([jnp.tri(3)]*20*10, axis=0).reshape(20, 10, 3, 3)
xs = jnp.ones((20, 10, 3))

# Create a batch of mvn's
mvns = eqx.filter_vmap(eqx.filter_vmap(dist.MultivariateNormalTri))(locs, scales_tri)

# Calling log_prob (expectedly) does not work because MultivariateNormalTri assumes k x k
# log_prob = mvn.log_prob(locs) # error

# We can manually vmap the computation, but then we get a vector of log-probs.
# We could add a sum, but it is better to encapsulate this in a single distribution
def simple_log_prob(d, x): return d.log_prob(x)
log_probs = eqx.filter_vmap(eqx.filter_vmap(simple_log_prob))(mvns, xs)
assert log_probs.shape == (20, 10,)

# If we attempt to use "Independent" to reinterpret the batch dims, we get a crash,
# because the computation dimensions are not being reinterpreted
reinterp_mvn = dist.Independent(mvns)
# reinterp_mvn.log_prob(xs) # error

# With the propose changes, we can successfully encapsulate the independent MVNs.
# We could also pass e.g. 1 here and manually vmap the last dim if desired.
reinterp_mvn = dist.Independent(mvns, reinterpreted_batch_ndims=2)
log_prob = reinterp_mvn.log_prob(xs)
assert jnp.isscalar(log_prob)
```