### PR TITLE
Implement covariance propagation for Transformed

### DIFF
--- a/distreqx/distributions/_transformed.py
+++ b/distreqx/distributions/_transformed.py
@@ -209,6 +209,42 @@ class Transformed(AbstractTransformed, AbstractSTDDistribution, strict=True):
     def variance(self) -> PyTree[Array]:
         raise NotImplementedError
 
+    def covariance(self) -> Array:
+        """Calculates the covariance.
+
+        Only supported if the bijector has a constant Jacobian,
+        and the underlying distribution has a `covariance` method.
+        """
+        if self.bijector.is_constant_jacobian and hasattr(
+            self.distribution, "covariance"
+        ):
+            base_cov = self.distribution.covariance()  # pyright: ignore
+
+            # 1. Setup linearization point
+            dummy_x = jnp.zeros(
+                self.distribution.event_shape, dtype=self.distribution.dtype
+            )
+
+            # 2. Define the Jacobian-Vector Product (push-forward) function
+            # jax.jvp(f, (x,), (v,)) returns (f(x), Jv)
+            def push_fwd(v):
+                return jax.jvp(self.bijector.forward, (dummy_x,), (v,))[1]
+
+            # 3. Apply J to the columns of base_cov: M = J @ Cx
+            # We vmap over the last dimension of Cx
+            j_cx = jax.vmap(push_fwd, in_axes=-1, out_axes=-1)(base_cov)
+
+            # 4. Apply J to the rows of the result: M @ J.T = (J @ M.T).T
+            # Applying J to the rows of M is equivalent to M @ J.T
+            return jax.vmap(push_fwd, in_axes=0, out_axes=0)(j_cx)
+
+        else:
+            raise NotImplementedError(
+                "`covariance` is not implemented for this transformed distribution. "
+                "Ensure the bijector has a constant Jacobian and the base "
+                "distribution supports covariance."
+            )
+
     def cdf(self, value: PyTree[Array]) -> PyTree[Array]:
         raise NotImplementedError
 

--- a/tests/transformed_test.py
+++ b/tests/transformed_test.py
@@ -8,7 +8,7 @@ import numpy as np
 from parameterized import parameterized  # type: ignore
 
 from distreqx.bijectors import ScalarAffine, Sigmoid
-from distreqx.distributions import Normal, Transformed
+from distreqx.distributions import MultivariateNormalTri, Normal, Transformed
 
 
 class TransformedTest(TestCase):
@@ -96,3 +96,18 @@ class TransformedTest(TestCase):
         x = jnp.zeros(())
         y = f(x, dist)
         self.assertIsInstance(y, jax.Array)
+
+    def test_covariance_constant_jacobian(self):
+        # Setup a 3D Multivariate Normal with Identity Covariance
+        loc = 1.0 * jnp.zeros(3)
+        scale_tri = 1.0 * jnp.eye(3)
+        base_dist = MultivariateNormalTri(loc, scale_tri)
+
+        # Scale by 2.0. Expected covariance should scale by a factor of 4.0
+        bijector = ScalarAffine(shift=jnp.array(1.0), scale=jnp.array(2.0))
+        dist = Transformed(base_dist, bijector)
+
+        expected_cov = 4.0 * jnp.eye(3)
+        actual_cov = dist.covariance()
+
+        np.testing.assert_allclose(actual_cov, expected_cov, rtol=1e-5)


### PR DESCRIPTION
Adds propagation of covariance to a Transformed distribution (when supported) using the Jacobian-vector product.

Edit: It seems there is more to this PR than I imagined, specifically regarding bijectors like Reshape and Transpose. Will investigate further