### PR TITLE
Add ImproperUniform

### DIFF
--- a/distreqx/distributions/__init__.py
+++ b/distreqx/distributions/__init__.py
@@ -10,6 +10,7 @@ from ._distribution import (
     AbstractSurvivalDistribution as AbstractSurvivalDistribution,
 )
 from ._gamma import Gamma as Gamma
+from ._improper_uniform import ImproperUniform as ImproperUniform
 from ._independent import Independent as Independent
 from ._logistic import Logistic as Logistic
 from ._mixture_same_family import MixtureSameFamily as MixtureSameFamily

--- a/distreqx/distributions/_improper_uniform.py
+++ b/distreqx/distributions/_improper_uniform.py
@@ -1,0 +1,87 @@
+import jax.numpy as jnp
+from jaxtyping import Array, Key
+
+from ._distribution import AbstractDistribution
+
+
+class ImproperUniform(
+    AbstractDistribution,
+    strict=True,
+):
+    """Improper Uniform distribution over the entire real line.
+
+    This distribution has an unnormalized probability density of 1 everywhere,
+    meaning its `log_prob` evaluates to 0. As an improper distribution, it
+    does not integrate to 1 and cannot be sampled from.
+    """
+
+    shape: tuple[int, ...] = ()
+
+    @property
+    def event_shape(self) -> tuple[int, ...]:
+        return self.shape
+
+    def sample(self, key: Key[Array, ""]) -> Array:
+        """Sampling is not defined for improper distributions."""
+        raise NotImplementedError("Cannot sample from an ImproperUniform distribution.")
+
+    def sample_and_log_prob(self, key: Key[Array, ""]) -> tuple[Array, Array]:
+        raise NotImplementedError("Cannot sample from an ImproperUniform distribution.")
+
+    def log_prob(self, value: Array) -> Array:
+        """Returns the unnormalized log probability (constant 0.0)."""
+        return jnp.zeros_like(value)
+
+    def prob(self, value: Array) -> Array:
+        """Returns the unnormalized probability (constant 1.0)."""
+        return jnp.ones_like(value)
+
+    def entropy(self) -> Array:
+        """Entropy of an improper uniform over the reals is infinite."""
+        return jnp.full(self.shape, jnp.inf)
+
+    def icdf(self, value: Array) -> Array:
+        raise NotImplementedError("icdf is undefined for an improper distribution.")
+
+    def log_cdf(self, value: Array) -> Array:
+        raise NotImplementedError("log_cdf is undefined for an improper distribution.")
+
+    def cdf(self, value: Array) -> Array:
+        raise NotImplementedError("cdf is undefined for an improper distribution.")
+
+    def survival_function(self, value: Array) -> Array:
+        raise NotImplementedError(
+            "survival_function is undefined for an improper distribution."
+        )
+
+    def log_survival_function(self, value: Array) -> Array:
+        raise NotImplementedError(
+            "log_survival_function is undefined for an improper distribution."
+        )
+
+    def mean(self) -> Array:
+        raise NotImplementedError("Mean is undefined for an improper distribution.")
+
+    def median(self) -> Array:
+        raise NotImplementedError("Median is undefined for an improper distribution.")
+
+    def variance(self) -> Array:
+        raise NotImplementedError("Variance is undefined for an improper distribution.")
+
+    def stddev(self) -> Array:
+        raise NotImplementedError(
+            "Standard deviation is undefined for an improper distribution."
+        )
+
+    def mode(self) -> Array:
+        raise NotImplementedError("Mode is undefined for an improper distribution.")
+
+    def kl_divergence(self, other_dist, **kwargs) -> Array:
+        raise NotImplementedError(
+            "KL divergence is undefined for an improper distribution."
+        )
+
+    def cross_entropy(self, other_dist, **kwargs) -> Array:
+        raise NotImplementedError(
+            "Cross entropy is undefined for an improper distribution."
+        )

--- a/distreqx/distributions/_improper_uniform.py
+++ b/distreqx/distributions/_improper_uniform.py
@@ -12,7 +12,7 @@ class ImproperUniform(
 
     This distribution has an unnormalized probability density of 1 everywhere,
     meaning its `log_prob` evaluates to 0. As an improper distribution, it
-    does not integrate to 1 and cannot be sampled from.
+    does not integrate to 1 and cannot be sampled.
     """
 
     shape: tuple[int, ...] = ()

--- a/distreqx/distributions/_improper_uniform.py
+++ b/distreqx/distributions/_improper_uniform.py
@@ -80,8 +80,3 @@ class ImproperUniform(
         raise NotImplementedError(
             "KL divergence is undefined for an improper distribution."
         )
-
-    def cross_entropy(self, other_dist, **kwargs) -> Array:
-        raise NotImplementedError(
-            "Cross entropy is undefined for an improper distribution."
-        )

--- a/distreqx/distributions/_improper_uniform.py
+++ b/distreqx/distributions/_improper_uniform.py
@@ -1,0 +1,92 @@
+import jax.numpy as jnp
+from jaxtyping import Array, Key
+
+from ._distribution import AbstractDistribution
+
+
+class ImproperUniform(
+    AbstractDistribution,
+):
+    """Improper Uniform distribution over the entire real line.
+
+    This distribution has an unnormalized probability density of 1 everywhere,
+    meaning its `log_prob` evaluates to 0. As an improper distribution, it
+    does not integrate to 1 and cannot be sampled.
+    """
+
+    shape: tuple[int, ...] = ()
+
+    @property
+    def event_shape(self) -> tuple[int, ...]:
+        return self.shape
+
+    @property
+    def support(self) -> tuple[Array, Array]:
+        """See `Distribution.support`.
+
+        The improper uniform is defined over the entire real line.
+        """
+        return (
+            jnp.full(self.shape, -jnp.inf),
+            jnp.full(self.shape, jnp.inf),
+        )
+
+    def sample(self, key: Key[Array, ""]) -> Array:
+        """Sampling is not defined for improper distributions."""
+        raise NotImplementedError("Cannot sample from an ImproperUniform distribution.")
+
+    def sample_and_log_prob(self, key: Key[Array, ""]) -> tuple[Array, Array]:
+        raise NotImplementedError("Cannot sample from an ImproperUniform distribution.")
+
+    def log_prob(self, value: Array) -> Array:
+        """Returns the unnormalized log probability (constant 0.0)."""
+        return jnp.zeros_like(value)
+
+    def prob(self, value: Array) -> Array:
+        """Returns the unnormalized probability (constant 1.0)."""
+        return jnp.ones_like(value)
+
+    def entropy(self) -> Array:
+        """Entropy of an improper uniform over the reals is infinite."""
+        return jnp.full(self.shape, jnp.inf)
+
+    def icdf(self, value: Array) -> Array:
+        raise NotImplementedError("icdf is undefined for an improper distribution.")
+
+    def log_cdf(self, value: Array) -> Array:
+        raise NotImplementedError("log_cdf is undefined for an improper distribution.")
+
+    def cdf(self, value: Array) -> Array:
+        raise NotImplementedError("cdf is undefined for an improper distribution.")
+
+    def survival_function(self, value: Array) -> Array:
+        raise NotImplementedError(
+            "survival_function is undefined for an improper distribution."
+        )
+
+    def log_survival_function(self, value: Array) -> Array:
+        raise NotImplementedError(
+            "log_survival_function is undefined for an improper distribution."
+        )
+
+    def mean(self) -> Array:
+        raise NotImplementedError("Mean is undefined for an improper distribution.")
+
+    def median(self) -> Array:
+        raise NotImplementedError("Median is undefined for an improper distribution.")
+
+    def variance(self) -> Array:
+        raise NotImplementedError("Variance is undefined for an improper distribution.")
+
+    def stddev(self) -> Array:
+        raise NotImplementedError(
+            "Standard deviation is undefined for an improper distribution."
+        )
+
+    def mode(self) -> Array:
+        raise NotImplementedError("Mode is undefined for an improper distribution.")
+
+    def kl_divergence(self, other_dist, **kwargs) -> Array:
+        raise NotImplementedError(
+            "KL divergence is undefined for an improper distribution."
+        )

--- a/docs/api/distributions/improper_uniform.md
+++ b/docs/api/distributions/improper_uniform.md
@@ -1,0 +1,4 @@
+# Improper Uniform
+
+::: distreqx.distributions.ImproperUniform
+---

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -112,6 +112,7 @@ nav:
             - 'api/distributions/gamma.md'
             - 'api/distributions/logistic.md'
             - 'api/distributions/independent.md'
+            - 'api/distributions/improper_uniform.md'
             - 'api/distributions/mixture_same_family.md'
             - 'api/distributions/uniform.md'
             - 'api/distributions/transformed.md'

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -111,6 +111,7 @@ nav:
             - 'api/distributions/categorical.md'
             - 'api/distributions/gamma.md'
             - 'api/distributions/logistic.md'
+            - 'api/distributions/improper_uniform.md'
             - 'api/distributions/independent.md'
             - 'api/distributions/mixture_same_family.md'
             - 'api/distributions/uniform.md'

--- a/tests/improper_uniform_test.py
+++ b/tests/improper_uniform_test.py
@@ -1,0 +1,77 @@
+from unittest import TestCase
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+
+from distreqx.distributions import ImproperUniform
+
+
+class ImproperUniformTest(TestCase):
+    def setUp(self):
+        self.key = jax.random.key(0)
+
+    def test_defaults_to_scalar_event_shape(self):
+        dist = ImproperUniform()
+        self.assertEqual(dist.event_shape, ())
+
+    def test_event_shape_and_support(self):
+        dist = ImproperUniform(shape=(2, 3))
+        self.assertEqual(dist.event_shape, (2, 3))
+
+        lower, upper = dist.support
+        self.assertEqual(lower.shape, (2, 3))
+        self.assertTrue(jnp.all(lower == -jnp.inf))
+        self.assertTrue(jnp.all(upper == jnp.inf))
+
+    def test_log_prob_and_prob_are_unnormalized_constants(self):
+        dist = ImproperUniform()
+        value = jnp.array([-1e6, 0.0, 1e6])
+
+        self.assertTrue(jnp.all(dist.log_prob(value) == 0.0))
+        self.assertTrue(jnp.all(dist.prob(value) == 1.0))
+
+    def test_entropy_is_infinite(self):
+        dist = ImproperUniform(shape=(3,))
+        self.assertTrue(jnp.all(dist.entropy() == jnp.inf))
+
+    def test_undefined_methods_raise(self):
+        dist = ImproperUniform()
+        value = jnp.array(0.0)
+
+        with self.assertRaisesRegex(NotImplementedError, "Cannot sample"):
+            dist.sample(self.key)
+        with self.assertRaisesRegex(NotImplementedError, "Cannot sample"):
+            dist.sample_and_log_prob(self.key)
+        with self.assertRaisesRegex(NotImplementedError, "undefined"):
+            dist.icdf(value)
+        with self.assertRaisesRegex(NotImplementedError, "undefined"):
+            dist.log_cdf(value)
+        with self.assertRaisesRegex(NotImplementedError, "undefined"):
+            dist.cdf(value)
+        with self.assertRaisesRegex(NotImplementedError, "undefined"):
+            dist.survival_function(value)
+        with self.assertRaisesRegex(NotImplementedError, "undefined"):
+            dist.log_survival_function(value)
+        with self.assertRaisesRegex(NotImplementedError, "undefined"):
+            dist.mean()
+        with self.assertRaisesRegex(NotImplementedError, "undefined"):
+            dist.median()
+        with self.assertRaisesRegex(NotImplementedError, "undefined"):
+            dist.variance()
+        with self.assertRaisesRegex(NotImplementedError, "undefined"):
+            dist.stddev()
+        with self.assertRaisesRegex(NotImplementedError, "undefined"):
+            dist.mode()
+        with self.assertRaisesRegex(NotImplementedError, "undefined"):
+            dist.kl_divergence(dist)
+
+    def test_jittable(self):
+        @eqx.filter_jit
+        def f(dist, value):
+            return dist.log_prob(value), dist.prob(value)
+
+        dist = ImproperUniform()
+        log_prob, prob = f(dist, jnp.array(1.0))
+        self.assertIsInstance(log_prob, jax.Array)
+        self.assertIsInstance(prob, jax.Array)


### PR DESCRIPTION
This is the canonical "Identity distribution". I've found that I've needed it as a placeholder many times when dealing with complex PyTrees.

For example, in my library [Parax](https://github.com/gvcallen/parax) (which uses `distreqx`), you can attach distributions as metadata to PyTree nodes and then using `tree_joint` to extract the joint distribution over the resultant PyTree. Without an "identity" distribution, users cannot have raw JAX array's and Parax variables alongside.