### PR TITLE
Fix Transformed/Chain for pytree-valued bijectors

### DIFF
--- a/distreqx/bijectors/_chain.py
+++ b/distreqx/bijectors/_chain.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Sequence
 
-from jaxtyping import Array
+from jaxtyping import Array, PyTree
 
 from ._bijector import (
     AbstractBijector,
@@ -64,19 +64,19 @@ class Chain(AbstractFwdLogDetJacBijector, AbstractInvLogDetJacBijector):
         self._is_constant_jacobian = is_constant_jacobian
         self._is_constant_log_det = is_constant_log_det
 
-    def forward(self, x: Array) -> Array:
+    def forward(self, x: PyTree) -> PyTree:
         """Computes y = f(x)."""
         for bijector in reversed(self.bijectors):
             x = bijector.forward(x)
         return x
 
-    def inverse(self, y: Array) -> Array:
+    def inverse(self, y: PyTree) -> PyTree:
         """Computes x = f^{-1}(y)."""
         for bijector in self.bijectors:
             y = bijector.inverse(y)
         return y
 
-    def forward_and_log_det(self, x: Array) -> tuple[Array, Array]:
+    def forward_and_log_det(self, x: PyTree) -> tuple[PyTree, Array]:
         """Computes y = f(x) and log|det J(f)(x)|."""
         x, log_det = self.bijectors[-1].forward_and_log_det(x)
         for bijector in reversed(self.bijectors[:-1]):
@@ -84,7 +84,7 @@ class Chain(AbstractFwdLogDetJacBijector, AbstractInvLogDetJacBijector):
             log_det += ld
         return x, log_det
 
-    def inverse_and_log_det(self, y: Array) -> tuple[Array, Array]:
+    def inverse_and_log_det(self, y: PyTree) -> tuple[PyTree, Array]:
         """Computes x = f^{-1}(y) and log|det J(f^{-1})(y)|."""
         y, log_det = self.bijectors[0].inverse_and_log_det(y)
         for bijector in self.bijectors[1:]:

--- a/distreqx/distributions/_transformed.py
+++ b/distreqx/distributions/_transformed.py
@@ -29,36 +29,38 @@ class AbstractTransformed(
     bijector: eqx.AbstractVar[AbstractBijector]
 
     def _infer_shapes_and_dtype(self):
-        """Infer the event shape by tracing `forward`."""
+        """Infer the event shape and dtype by tracing `forward`."""
         dummy_shape = self.distribution.event_shape
         dummy = jnp.zeros(dummy_shape, dtype=self.distribution.dtype)
         shape_dtype = jax.eval_shape(self.bijector.forward, dummy)
-        return shape_dtype.shape, shape_dtype.dtype
+        shapes = jax.tree_util.tree_map(lambda x: x.shape, shape_dtype)
+        dtypes = jax.tree_util.tree_map(lambda x: x.dtype, shape_dtype)
+        return shapes, dtypes
 
     @property
-    def dtype(self) -> jnp.dtype:
+    def dtype(self) -> PyTree:
         """See `Distribution.dtype`."""
         return self._infer_shapes_and_dtype()[1]
 
     @property
-    def event_shape(self) -> tuple[int, ...]:
+    def event_shape(self) -> PyTree:
         """See `Distribution.event_shape`."""
         return self._infer_shapes_and_dtype()[0]
 
-    def log_prob(self, value: Array) -> Array:
+    def log_prob(self, value: PyTree) -> Array:
         """See `Distribution.log_prob`."""
         x, ildj_y = self.bijector.inverse_and_log_det(value)
         lp_x = self.distribution.log_prob(x)
         lp_y = lp_x + ildj_y
         return lp_y
 
-    def sample(self, key: Key[Array, ""]) -> Array:
+    def sample(self, key: Key[Array, ""]) -> PyTree:
         """Return a sample."""
         x = self.distribution.sample(key)
         y = self.bijector.forward(x)
         return y
 
-    def sample_and_log_prob(self, key: Key[Array, ""]) -> tuple[Array, Array]:
+    def sample_and_log_prob(self, key: Key[Array, ""]) -> tuple[PyTree, Array]:
         """Return a sample and log prob.
 
         This function is more efficient than calling `sample` and `log_prob`
@@ -78,7 +80,7 @@ class AbstractTransformed(
         lp_y = jnp.subtract(lp_x, fldj)
         return y, lp_y
 
-    def entropy(self, input_hint: Optional[Array] = None) -> Array:
+    def entropy(self, input_hint: Optional[PyTree] = None) -> Array:
         """Calculates the Shannon entropy (in Nats).
 
         Only works for bijectors with constant Jacobian determinant.
@@ -175,7 +177,7 @@ class Transformed(AbstractTransformed, AbstractSTDDistribution):
         self.distribution = distribution
         self.bijector = bijector
 
-    def mean(self) -> Array:
+    def mean(self) -> PyTree:
         """Calculates the mean."""
         if self.bijector.is_constant_jacobian:
             return self.bijector.forward(self.distribution.mean())
@@ -185,7 +187,7 @@ class Transformed(AbstractTransformed, AbstractSTDDistribution):
                 "because its bijector's Jacobian is not known to be constant."
             )
 
-    def mode(self) -> Array:
+    def mode(self) -> PyTree:
         """Calculates the mode."""
         if self.bijector.is_constant_log_det:
             return self.bijector.forward(self.distribution.mode())

--- a/distreqx/distributions/_transformed.py
+++ b/distreqx/distributions/_transformed.py
@@ -33,8 +33,8 @@ class AbstractTransformed(
         dummy_shape = self.distribution.event_shape
         dummy = jnp.zeros(dummy_shape, dtype=self.distribution.dtype)
         shape_dtype = jax.eval_shape(self.bijector.forward, dummy)
-        shapes = jax.tree_util.tree_map(lambda x: x.shape, shape_dtype)
-        dtypes = jax.tree_util.tree_map(lambda x: x.dtype, shape_dtype)
+        shapes = jax.tree.map(lambda x: x.shape, shape_dtype)
+        dtypes = jax.tree.map(lambda x: x.dtype, shape_dtype)
         return shapes, dtypes
 
     @property

--- a/tests/chain_test.py
+++ b/tests/chain_test.py
@@ -6,9 +6,35 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 
-from distreqx.bijectors import AbstractBijector, Chain, ScalarAffine, Tanh
+from distreqx.bijectors import (
+    AbstractBijector,
+    AbstractForwardInverseBijector,
+    AbstractFwdLogDetJacBijector,
+    AbstractInvLogDetJacBijector,
+    Chain,
+    ScalarAffine,
+    Tanh,
+)
 
 RTOL = 1e-2
+
+
+class DummyPytreeBijector(
+    AbstractForwardInverseBijector,
+    AbstractFwdLogDetJacBijector,
+    AbstractInvLogDetJacBijector,
+):
+    _is_constant_jacobian: bool = True
+    _is_constant_log_det: bool = True
+
+    def forward_and_log_det(self, x):
+        return {"a": x[:1], "b": x[1:]}, jnp.zeros(())
+
+    def inverse_and_log_det(self, y):
+        return jnp.concatenate([y["a"], y["b"]]), jnp.zeros(())
+
+    def same_as(self, other):
+        return type(other) is DummyPytreeBijector
 
 
 class ChainTest(TestCase):
@@ -23,6 +49,13 @@ class ChainTest(TestCase):
     def test_raises_on_empty_list(self):
         with self.assertRaises(ValueError):
             Chain([])
+
+    def test_pytree_valued_bijector(self):
+        bijector = Chain([DummyPytreeBijector()])
+        x = jnp.arange(2.0)
+        y = bijector.forward(x)
+        self.assertEqual(set(y.keys()), {"a", "b"})
+        np.testing.assert_array_equal(bijector.inverse(y), x)
 
     def test_jittable(self):
         @jax.jit

--- a/tests/transformed_test.py
+++ b/tests/transformed_test.py
@@ -7,8 +7,32 @@ import jax.numpy as jnp
 import numpy as np
 from parameterized import parameterized  # type: ignore
 
-from distreqx.bijectors import ScalarAffine, Sigmoid
+from distreqx.bijectors import (
+    AbstractForwardInverseBijector,
+    AbstractFwdLogDetJacBijector,
+    AbstractInvLogDetJacBijector,
+    ScalarAffine,
+    Sigmoid,
+)
 from distreqx.distributions import Normal, Transformed
+
+
+class DummyPytreeBijector(
+    AbstractForwardInverseBijector,
+    AbstractFwdLogDetJacBijector,
+    AbstractInvLogDetJacBijector,
+):
+    _is_constant_jacobian: bool = True
+    _is_constant_log_det: bool = True
+
+    def forward_and_log_det(self, x):
+        return {"a": x[:1], "b": x[1:]}, jnp.zeros(())
+
+    def inverse_and_log_det(self, y):
+        return jnp.concatenate([y["a"], y["b"]]), jnp.zeros(())
+
+    def same_as(self, other):
+        return type(other) is DummyPytreeBijector
 
 
 class TransformedTest(TestCase):
@@ -84,6 +108,18 @@ class TransformedTest(TestCase):
         result_inv = distreqx_dist2.kl_divergence(distreqx_dist1)
         np.testing.assert_allclose(result_fwd, expected_result_fwd, rtol=1e-2)
         np.testing.assert_allclose(result_inv, expected_result_inv, rtol=1e-2)
+
+    def test_event_shape_and_dtype_for_pytree_valued_bijector(self):
+        base = Normal(jnp.zeros(2), jnp.ones(2))
+        dist = Transformed(base, DummyPytreeBijector())
+
+        self.assertEqual(dist.event_shape, {"a": (1,), "b": (1,)})
+        self.assertEqual(dist.dtype, {"a": jnp.zeros(1).dtype, "b": jnp.zeros(1).dtype})
+
+        sample = dist.sample(jax.random.key(0))
+        self.assertEqual(set(sample.keys()), {"a", "b"})
+        concatenated = jnp.concatenate([sample["a"], sample["b"]])
+        np.testing.assert_allclose(dist.log_prob(sample), base.log_prob(concatenated))
 
     def test_jittable(self):
         @jax.jit


### PR DESCRIPTION
`AbstractTransformed._infer_shapes_and_dtype` read `.shape`/`.dtype` directly off the traced output of `bijector.forward`, which only works if that output is a single array. For a bijector whose forward pass returns a pytree, `jax.eval_shape` instead returns a matching pytree of `ShapeDtypeStruct`s, so `.shape`/`.dtype` need to be mapped over it leaf-wise.

`Chain.forward`/`inverse`/`forward_and_log_det`/`inverse_and_log_det` were also typed as `Array -> Array`, narrower than `AbstractBijector`'s own `PyTree -> PyTree`, even though `Chain` just composes whatever bijectors it's given. This PR widens these, along with the `Transformed`/`AbstractTransformed` methods that carry values through a bijector (`sample`, `sample_and_log_prob`, `log_prob`, `entropy`, `mean`, `mode`).