### PR TITLE
docs: flesh out rendered docs homepage

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -8,10 +8,54 @@ distreqx (pronounced "dist-rex") is a [JAX](https://github.com/google/jax)-based
 
 The origin of this package is a reimplementation of [distrax](https://github.com/google-deepmind/distrax), (which is a subset of [TensorFlow Probability (TFP)](https://github.com/tensorflow/probability), with some new features and emphasis on jax compatibility) using [equinox](https://github.com/patrick-kidger/equinox). As a result, much of the original code/comments/documentation/tests are directly taken or adapted from distrax (original distrax copyright available at end of README.)
 
-Current features include:
 
-- Probability distributions
-- Bijectors
+## Why distreqx?
+
+- **Pure JAX** — No TensorFlow dependency. Works seamlessly with the modern JAX ecosystem.
+- **Equinox-based** — Distributions and bijectors are pytrees, so they play nicely with `jit`, `vmap`, `grad`, and other JAX transformations out of the box.
+- **Actively maintained** — Unlike distrax, which has been largely unmaintained, distreqx receives regular updates and bug fixes.
+- **Strict design patterns** — Follows the [abstract/final pattern](https://docs.kidger.site/equinox/pattern/) for clean, extensible code.
+- **No batch dimension** — Uses `vmap` for batching, which is more explicit and composable than implicit batch dimensions.
+
+
+## Features at a Glance
+
+### Distributions
+
+| Distribution | Class |
+|---|---|
+| Normal (univariate) | `distributions.Normal` |
+| Multivariate Normal (diagonal) | `distributions.MultivariateNormalDiag` |
+| Multivariate Normal (full covariance) | `distributions.MultivariateNormalFullCovariance` |
+| Multivariate Normal (triangular) | `distributions.MultivariateNormalTri` |
+| Multivariate Normal (from bijector) | `distributions.MultivariateNormalFromBijector` |
+| Bernoulli | `distributions.Bernoulli` |
+| Beta | `distributions.Beta` |
+| Categorical | `distributions.Categorical` |
+| One-Hot Categorical | `distributions.OneHotCategorical` |
+| Gamma | `distributions.Gamma` |
+| Logistic | `distributions.Logistic` |
+| Uniform | `distributions.Uniform` |
+| Independent | `distributions.Independent` |
+| Empirical | `distributions.Empirical` |
+| Transformed | `distributions.Transformed` |
+| Mixture (same family) | `distributions.MixtureSameFamily` |
+
+### Bijectors
+
+| Bijector | Class |
+|---|---|
+| Scalar Affine | `bijectors.ScalarAffine` |
+| Shift | `bijectors.Shift` |
+| Sigmoid | `bijectors.Sigmoid` |
+| Tanh | `bijectors.Tanh` |
+| Identity | `bijectors.Identity` |
+| Block | `bijectors.Block` |
+| Chain | `bijectors.Chain` |
+| Inverse | `bijectors.Inverse` |
+| Diagonal Linear | `bijectors.DiagLinear` |
+| Triangular Linear | `bijectors.TriangularLinear` |
+| Rational Quadratic Spline | `bijectors.RationalQuadraticSpline` |
 
 
 ## Installation
@@ -31,7 +75,9 @@ pip install -e .
 Requires Python 3.10+, JAX 0.4.11+, and [Equinox](https://github.com/patrick-kidger/equinox) 0.11.0+.
 
 
-## Quick example
+## Quick Examples
+
+### Distributions
 
 ```python
 import jax
@@ -48,6 +94,73 @@ samples = dist.sample(key)
 
 print(dist.log_prob(samples))
 ```
+
+### Bijectors
+
+```python
+import jax
+from jax import numpy as jnp
+from distreqx import bijectors
+
+# Create an affine bijector: y = 2x + 1
+bijector = bijectors.ScalarAffine(shift=1.0, scale=2.0)
+
+x = jnp.array([0.0, 1.0, 2.0])
+y = bijector.forward(x)          # [1., 3., 5.]
+x_reconstructed = bijector.inverse(y)  # [0., 1., 2.]
+
+# Log determinant of the Jacobian (useful for normalizing flows)
+log_det = bijector.forward_log_det_jacobian(x)
+```
+
+### Transformed Distributions
+
+```python
+import jax
+from jax import numpy as jnp
+from distreqx import distributions, bijectors
+
+# Create a log-normal distribution by transforming a normal with exp
+normal = distributions.Normal(loc=0.0, scale=1.0)
+exp_bijector = bijectors.Chain([bijectors.ScalarAffine(shift=0.0, scale=1.0)])
+
+log_normal = distributions.Transformed(
+    distribution=normal,
+    bijector=exp_bijector
+)
+
+key = jax.random.key(42)
+samples = log_normal.sample(key)
+log_prob = log_normal.log_prob(samples)
+```
+
+### JAX Transformations
+
+All distributions and bijectors work seamlessly with JAX transformations:
+
+```python
+import jax
+from jax import numpy as jnp
+from distreqx import distributions
+
+# vmap over different distribution parameters
+mus = jnp.array([0.0, 1.0, 2.0])
+sigmas = jnp.array([0.5, 1.0, 1.5])
+
+# Create and sample from multiple distributions at once
+keys = jax.random.split(jax.random.key(0), 3)
+samples = jax.vmap(
+    lambda mu, sigma, key: distributions.Normal(mu, sigma).sample(key)
+)(mus, sigmas, keys)
+
+# Gradient through log_prob
+def neg_log_prob(mu, x):
+    return -distributions.Normal(mu, 1.0).log_prob(x)
+
+grad_fn = jax.grad(neg_log_prob)
+print(grad_fn(0.0, 1.0))  # Gradient of NLL w.r.t. mu
+```
+
 
 ## Differences with Distrax
 


### PR DESCRIPTION
## Summary
Improves the documentation homepage by adding several new sections that help newcomers understand the library at a glance.

## Changes
- **Why distreqx?** section summarizing key advantages (pure JAX, equinox-based, actively maintained, strict design patterns, no batch dimension)
- **Features at a Glance** tables listing all available distributions and bijectors with their class names
- **Additional quick examples** for bijector usage, transformed distributions, and JAX transformations (vmap, grad)
- Renamed Quick example to Quick Examples to reflect multiple examples

## Motivation
Addresses #22. New users benefit from seeing the full scope of available distributions/bijectors upfront, understanding why to choose distreqx over alternatives, and seeing examples beyond just distributions.

## Testing
Documentation-only change. Verified the markdown renders correctly and all references are valid.